### PR TITLE
Restore correct lines on DS4Windows Mode User Guide

### DIFF
--- a/docs/projects/DsHidMini/DS4-Mode-User-Guide.md
+++ b/docs/projects/DsHidMini/DS4-Mode-User-Guide.md
@@ -46,10 +46,8 @@ From here, DS4Windows can be used _mostly_ as usual. XInput and DS4 emulation, a
 
 ## Light Bar color to LEDs translation
 
-!!! important "This section is deprecated"
-    As of DsHidMini version `1.4.222` (or newer) **and** DS4Windows version `3.0.4` (or newer) hiding the controller is not necessary anymore!
-
-Some games can end-up detecting two controllers/inputs when using DS3 with DS4Windows. This happens because the game is picking both the real controller input and the emulated Xbox/DualShock 4 controller created by DS4Windows. The 3 possible ways to solve this are:
+!!! note "Optional section"
+    Read this section if you want to control your controller's LEDs to show the current battery or selected profile
 
 By setting the correct Light Bar color values in the profile settings it is possible to control the LEDs on the DS3, which can be useful to:
 


### PR DESCRIPTION
Some lines from the now removed `Solving double input issue in games` end up replacing parts of the `Light bar color to LEDs translation` section on a previous merge. This commit restores the correct lines.