### PR TITLE
Update Compatibility BT Devices DK-AC-BTU50

### DIFF
--- a/docs/projects/BthPS3/Compatible-Bluetooth-Devices.md
+++ b/docs/projects/BthPS3/Compatible-Bluetooth-Devices.md
@@ -19,6 +19,7 @@ Hardware ID | Name | Status | Remarks
 `USB\VID_0E5E&PID_6622` | Conwise CW6622 | ❔ | 
 `USB\VID_1131&PID_1001` | ISSC KY-BT100 | ❔ | 
 `USB\VID_0BB4&PID_0306` | Broadcom BCM20703 | ❌ | HTC VIVE (Steam OpenVR) customized device. Can be used in parallel with "vanilla" dongle without issues though.
+`USB\VID_0BDA&PID_8771` | Dark Bluetooth 5.0 Mini Dongle Usb Receiver (DK-AC-BTU50) | ❌ | Realtek Bluetooth 5.0 Adapter shown at Device Manager.
 
 ## Integrated Modules/Chips in Laptops or other Devices
 


### PR DESCRIPTION
Event Viewer Warning : The command sent to the adapter has timed out; adapter did not respond.
OS: W11 PRO
Bluetooth Device: USB DONGLE - Dark Bluetooth 5.0 Mini Dongle Usb Receiver (DK-AC-BTU50)
Joystick: Fake Controller - Polosmart Psg04 Wireless Ps3 Gamepad POLO-214