### PR TITLE
More bottom space

### DIFF
--- a/docs/stylesheets/extra.css
+++ b/docs/stylesheets/extra.css
@@ -1,0 +1,4 @@
+/* More space at the bottom of the page */
+.md-footer {
+    margin-top: 1.5rem;
+}

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -21,6 +21,7 @@ extra:
     - icon: fontawesome/brands/discord
       link: https://discord.vigem.org
 extra_css:
+  - stylesheets/extra.css
   - stylesheets/glightbox.css
 extra_javascript:
   - javascripts/glightbox.js


### PR DESCRIPTION
By default, there is not enough space at the bottom of the page. This pull requests sets the bottom space equal to the top space.

### Before

![bildo](https://user-images.githubusercontent.com/39555268/130146958-a1b21582-5c7c-49c4-94d3-2b03b707d450.png)

### After

![bildo](https://user-images.githubusercontent.com/39555268/130146908-2b190b1b-30a0-4dcc-8046-ee7d721a388d.png)
