### PR TITLE
Removed DS4W from the "Known users of HG" page

### DIFF
--- a/docs/projects/HidGuardian/Hall-of-fame.md
+++ b/docs/projects/HidGuardian/Hall-of-fame.md
@@ -2,12 +2,6 @@
 
 Over its lifespan the project has seen some adoption in the following projects. This list is most probably incomplete, please help expanding it by [contributing to it](https://github.com/ViGEm/ViGEm.github.io). The projects listed are made by 3rd party individuals, we can not provide any form of warranty or support. Appearance in no particular order.
 
-## DS4Windows
-
-[![Website](https://img.shields.io/badge/Website-yellowgreen?logo=html5)](https://ryochan7.github.io/ds4windows-site/) [![GitHub](https://img.shields.io/badge/GitHub-yellowgreen?logo=github)](https://github.com/Ryochan7/DS4Windows/)
-
-DS4Windows is a portable program that allows you to get the best experience while using a DualShock 4 on your PC. By emulating a Xbox 360 controller, many more games are accessible.
-
 ## x360ce
 
 [![Website](https://img.shields.io/badge/Website-yellowgreen?logo=html5)](https://www.x360ce.com/) [![GitHub](https://img.shields.io/badge/GitHub-yellowgreen?logo=github)](https://github.com/x360ce/x360ce)


### PR DESCRIPTION
Support for HG was removed in DS4Windows v3.0.8 in favor of HidHide. As such, it will not ask for HidGuardian access anymore and it won't be able to detect HidGuardian Hidden devices unless the user manually concedes access to it via another software.