### PR TITLE
Added missing lines required for content tabs

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -39,6 +39,7 @@ markdown_extensions:
       emoji_generator: !!python/name:materialx.emoji.to_svg
   - pymdownx.highlight:
   - pymdownx.tabbed:
+      alternate_style: true 
   - pymdownx.superfences:
   - pymdownx.keys:
   - pymdownx.tasklist:


### PR DESCRIPTION
Accordingly to material for mkdocs documentation, to enable content tabs you need the following:

```
markdown_extensions:
  - pymdownx.superfences
  - pymdownx.tabbed:
      alternate_style: true 
```

The last line was missing from the mkdocs.yml file

source: https://squidfunk.github.io/mkdocs-material/reference/content-tabs/#content-tabs